### PR TITLE
Harden pnpm configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: © 2025 Nikita Karamov <me@kytta.dev>
 # SPDX-License-Identifier: CC0-1.0
 
+blockExoticSubdeps: true
 onlyBuiltDependencies:
   - esbuild
   - sharp

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,9 +5,10 @@
 # SPDX-License-Identifier: CC0-1.0
 
 blockExoticSubdeps: true
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
+allowBuilds:
+  esbuild: true
+  sharp: true
+strictDepBuilds: true
 
 minimumReleaseAge: 4320
 minimumReleaseAgeExclude:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,3 @@ allowBuilds:
 strictDepBuilds: true
 
 minimumReleaseAge: 4320
-minimumReleaseAgeExclude:
-  # Renovate security update: @astrojs/node@10.0.5
-  - "@astrojs/node@10.0.5"


### PR DESCRIPTION
Closes #266.

Partially remediates:
- CVE-2025-69264 / GHSA-379q-355j-w6rj
- CVE-2025-69263 / GHSA-7vhp-vf5g-r2fw
- CVE-2026-24056 / GHSA-m733-5w8f-5ggw
- CVE-2026-48995 / GHSA-hg3w-7f8c-63hp

The rest are non-actionable or not a problem