### PR TITLE
Show validation issue messages for invalid domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ official Docker images.
 
 - fixed duplicate "on on GitHub" in some translations
 - multiple vulnerable dependencies were patched
+- errors on invalid domain names are now human-readable (thx [Kirill](https://github.com/vetrovk)!)
 
 ### Changed
 

--- a/src/components/instance-select.astro
+++ b/src/components/instance-select.astro
@@ -22,6 +22,8 @@ const { instance, errors } = Astro.props;
 			name="instance"
 			id="instance"
 			list="popular-instances"
+			minlength="5"
+			pattern=".*[.].*"
 			required
 			aria-invalid={Boolean(errors)}
 			aria-errormessage={errors ? "instance-error" : undefined}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,7 @@
  * SPDX-FileCopyrightText: © 2023 Nikita Karamov <me@kytta.dev>
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-import { actions } from "astro:actions";
+import { actions, isInputError } from "astro:actions";
 
 import Layout from "@layouts/layout.astro";
 import InstanceSelect from "@components/instance-select.astro";
@@ -36,7 +36,10 @@ if (Astro.request.method === "POST") {
 		const { data, error } = await Astro.callAction(actions.detect, instance);
 
 		if (error) {
-			errors.instance += error.message + " ";
+			errors.instance +=
+				(isInputError(error)
+					? error.issues.map((issue) => issue.message).join(" ")
+					: error.message) + " ";
 		} else {
 			detection = data;
 		}


### PR DESCRIPTION
Fixes #288.

This updates the invalid-domain validation error display to show the human-readable validation issue message instead of Astro's serialized `ActionInputError.message`.

For input validation errors, the page now displays `issues[].message`. Other backend errors still fall back to `error.message`.

Validation:
- `pnpm run check:astro`
- `pnpm run check:eslint`
- `pnpm run check:prettier`
- `pnpm run check:stylelint`
- `pnpm run build`
- `git diff --check`

Manual validation:
- `invalid-domain` shows only `Invalid string: must include "."`
- serialized `Failed to validate: [...]` metadata is no longer shown
- non-input backend error fallback still works