### PR TITLE
Allow 4-character domain names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ official Docker images.
 - fixed duplicate "on on GitHub" in some translations
 - multiple vulnerable dependencies were patched
 - errors on invalid domain names are now human-readable (thx [Kirill](https://github.com/vetrovk)!)
+- four-character domain names (like `c.im`) are now also valid
 
 ### Changed
 

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -19,7 +19,7 @@ export type Detection = ProjectPublishConfig & {
 
 export const server = {
 	detect: defineAction({
-		input: z.string().min(5).includes("."),
+		input: z.string().min(4).includes("."),
 		handler: async (domain): Promise<Detection> => {
 			const softwareName = await getSoftwareName(domain);
 			if (softwareName === undefined) {

--- a/src/components/instance-select.astro
+++ b/src/components/instance-select.astro
@@ -22,7 +22,7 @@ const { instance, errors } = Astro.props;
 			name="instance"
 			id="instance"
 			list="popular-instances"
-			minlength="5"
+			minlength="4"
 			pattern=".*[.].*"
 			required
 			aria-invalid={Boolean(errors)}


### PR DESCRIPTION
2fa5f8b did set min length for domain name to _five_ characters. This does not make sense: A publicly routable domain (assumed that it should have at least two segments) can be 4 chars long: one for the second level, two for the top level, and a period. Example: [c.im](https://c.im/), a Mastodon instance.

This PR fixes this.